### PR TITLE
update release procedure, add .npmignore, etc

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,7 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+max_line_length = 100
 
 [*.md]
 trim_trailing_whitespace = false

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,188 @@
+Development
+===========
+
+## Build
+
+Build for production use (NPM, bower, etc) and create `dist` UMD bundles
+(min'ed, non-min'ed)
+
+```
+$ npm run build
+```
+
+Note that `dist/` files are only updated and committed on **tagged releases**.
+
+
+## Development
+
+All development tasks consist of watching the demo bundle, the test bundle
+and launching a browser pointed to the demo page.
+
+Run the `demo` application with watched rebuilds:
+
+```
+$ npm run dev       # dev test/app server (OR)
+$ npm run open-dev  # dev servers _and a browser window opens!_
+```
+
+From there you can see:
+
+* Demo app: [127.0.0.1:3000](http://127.0.0.1:3000/)
+* Client tests: [127.0.0.1:3001/test/client/test.html](http://127.0.0.1:3001/test/client/test.html)
+
+
+## Programming Guide
+
+### Logging
+
+We use the following basic pattern for logging:
+
+```js
+if (process.env.NODE_ENV !== "production") {
+  /* eslint-disable no-console */
+  if (typeof console !== "undefined" && console.warn) {
+    console.warn("Oh noes! bad things happened.");
+  }
+  /* eslint-enable no-console */
+}
+```
+
+Replace `console.warn` in the condtional + method call as appropriate.
+
+Breaking this down:
+
+* `process.env.NODE_ENV !== "production"` - This part removes all traces of
+  the code in the production bundle, to save on file size. This _also_ means
+  that no warnings will be displayed in production.
+* `typeof console !== "undefined" && console.METHOD` - A permissive check to
+  make sure the `console` object exists and can use the appropriate `METHOD` -
+  `warn`, `info`, etc.
+
+To signal production mode to the webpack build, declare the `NODE_ENV` variable:
+
+```js
+new webpack.DefinePlugin({
+  "process.env.NODE_ENV": JSON.stringify("production")
+})
+```
+
+Unfortunately, we need to do _all_ of this every time to have Uglify properly
+drop the code, but with this trick, the production bundle has no change in code
+size.
+
+
+## Quality
+
+### In Development
+
+During development, you are expected to be running either:
+
+```
+$ npm run dev
+```
+
+to build the lib and test files. With these running, you can run the faster
+
+```
+$ npm run check-dev
+```
+
+Command. It is comprised of:
+
+```
+$ npm run lint
+$ npm run test-dev
+```
+
+Note that the tests here are not instrumented for code coverage and are thus
+more development / debugging friendly.
+
+### Continuous Integration
+
+CI doesn't have source / test file watchers, so has to _build_ the test files
+via the commands:
+
+```
+$ npm run check     # PhantomJS only
+$ npm run check-cov # (OR) PhantomJS w/ coverage
+$ npm run check-ci  # (OR) PhantomJS,Firefox + coverage - available on Travis.
+```
+
+Which is currently comprised of:
+
+```
+$ npm run lint      # AND ...
+
+$ npm run test      # PhantomJS only
+$ npm run test-cov  # (OR) PhantomJS w/ coverage
+$ npm run test-ci   # (OR) PhantomJS,Firefox + coverage
+```
+
+Note that `(test|check)-(cov|ci)` run code coverage and thus the
+test code may be harder to debug because it is instrumented.
+
+### Client Tests
+
+The client tests rely on webpack dev server to create and serve the bundle
+of the app/test code at: http://127.0.0.1:3001/assets/main.js which is done
+with the task `npm run server-test` (part of `npm dev`).
+
+#### Code Coverage
+
+Code coverage reports are outputted to:
+
+```
+coverage/
+  client/
+    BROWSER_STRING/
+      lcov-report/index.html  # Viewable web report.
+```
+
+## Releases
+
+**IMPORTANT - NPM**: To correctly run `preversion` your first step is to make
+sure that you have a very modern `npm` binary:
+
+```
+$ npm install -g npm
+```
+
+Built files in `dist/` should **not** be committeed during development or PRs.
+Instead we _only_ build and commit them for published, tagged releases. So
+the basic workflow is:
+
+```
+# Make sure you have a clean, up-to-date `master`
+$ git pull
+$ git status # (should be no changes)
+
+# Choose a semantic update for the new version.
+# If you're unsure, read about semantic versioning at http://semver.org/
+$ npm version major|minor|patch -m "Version %s - INSERT_REASONS"
+
+# ... the `dist/` and `lib/` directories are now built, `package.json` is
+# updated, and the appropriate files are committed to git (but unpushed).
+#
+# *Note*: `lib/` is uncommitted, but built and must be present to push to npm.
+
+# Check that everything looks good in last commit and push.
+$ git diff HEAD^ HEAD
+$ git push && git push --tags
+# ... the project is now pushed to GitHub and available to `bower`.
+
+# And finally publish to `npm`!
+$ npm publish
+```
+
+And you've published!
+
+For additional information on the underlying NPM technologies and approaches,
+please review:
+
+* [`npm version`](https://docs.npmjs.com/cli/version): Runs verification,
+  builds `dist/` and `lib/` via `scripts` commands.
+    * Our scripts also run the applicable `git` commands, so be very careful
+      when running out `version` commands.
+* [`npm publish`](https://docs.npmjs.com/cli/publish): Uploads to NPM.
+    * **NOTE**: We don't _build_ in `prepublish` because of the
+      [`npm install` runs `npm prepublish` bug](https://github.com/npm/npm/issues/3059)

--- a/README.md
+++ b/README.md
@@ -1,166 +1,17 @@
 [![Travis Status][trav_img]][trav_site]
 
 
-Victory Component Boilerplate
-===========================
-
-Boilerplate for developing a Victory Component!
-
-## The Generator
-
-We expect these opinions to change *often*.  We've written a yeoman generator to
-pull down the freshest copy of this repo whenever you use it.  It just copies
-this repo so you don't have to. Check it out
-[here](https://github.com/FormidableLabs/generator-formidable-react-component)
-
-
-## Build
-
-Build for production use (NPM, bower, etc).
-
-```
-$ npm run build
-```
-
-Which is composed of commands to create `dist` UMD bundles (min'ed, non-min'ed)
-
-```
-$ npm run build-dist
-```
-
-and the ES5 `lib`:
-
-```
-$ npm run build-lib
-```
-
-Note that `dist/` files are only updated and committed on **tagged releases**.
-
+Victory Tree
+============
 
 ## Development
 
-All development tasks consist of watching the demo bundle, the test bundle
-and launching a browser pointed to the demo page.
-
-Run the `demo` application in a browser window with hot reload:
-(More CPU usage, but faster, more specific updates)
-
-```
-$ npm run hot       # hot test/app server (OR)
-$ npm run open-hot  # hot servers _and a browser window opens!_
-```
-
-Run the `demo` application with watched rebuilds, but not hot reload:
-
-```
-$ npm run dev       # dev test/app server (OR)
-$ npm run open-dev  # dev servers _and a browser window opens!_
-```
-
-From there you can see:
-
-* Demo app: [127.0.0.1:3000](http://127.0.0.1:3000/)
-* Client tests: [127.0.0.1:3001/test/client/test.html](http://127.0.0.1:3001/test/client/test.html)
-
-## Quality
-
-### In Development
-
-During development, you are expected to be running either:
-
-```
-$ npm run dev
-$ npm run hot
-```
-
-to build the src and test files. With these running, you can run the faster
-
-```
-$ npm run check-dev
-```
-
-Command. It is comprised of:
-
-```
-$ npm run lint
-$ npm run test-dev
-```
-
-Note that the tests here are not instrumented for code coverage and are thus
-more development / debugging friendly.
-
-### Continuous Integration
-
-CI doesn't have source / test file watchers, so has to _build_ the test files
-via the commands:
-
-```
-$ npm run check     # PhantomJS only
-$ npm run check-cov # (OR) PhantomJS w/ coverage
-$ npm run check-ci  # (OR) PhantomJS,Firefox + coverage - available on Travis.
-```
-
-Which is currently comprised of:
-
-```
-$ npm run lint      # AND ...
-
-$ npm run test      # PhantomJS only
-$ npm run test-cov  # (OR) PhantomJS w/ coverage
-$ npm run test-ci   # (OR) PhantomJS,Firefox + coverage
-```
-
-Note that `(test|check)-(cov|ci)` run code coverage and thus the
-test code may be harder to debug because it is instrumented.
-
-### Client Tests
-
-The client tests rely on webpack dev server to create and serve the bundle
-of the app/test code at: http://127.0.0.1:3001/assets/main.js which is done
-with the task `npm run server-test` (part of `npm dev` and `npm hot`).
-
-#### Code Coverage
-
-Code coverage reports are outputted to:
-
-```
-coverage/
-  client/
-    BROWSER_STRING/
-      lcov-report/index.html  # Viewable web report.
-```
-
-## Releases
-
-Built files in `dist/` should **not** be committeed during development or PRs.
-Instead we _only_ build and commit them for published, tagged releases. So
-the basic workflow is:
-
-```
-# Update version
-$ vim package.json # and bump version
-$ git add package.json
-
-# Create the `dist/*{.js,.map}` files and publish working project to NPM.
-$ npm publish
-# ... the project is now _published_ and available to `npm`.
-
-# Commit, tag
-$ git add dist/
-$ git commit -m "Bump version to vVERS"
-$ git tag -a "vVERS" -m "Version VERS"
-$ git push
-$ git push --tags
-# ... the project is now pushed to GitHub and available to `bower`.
-```
-
-Side note: `npm publish` runs `npm prepublish` under the hood, which does the
-build.
+Please see [DEVELOPMENT](DEVELOPMENT.md)
 
 ## Contributing
 
 Please see [CONTRIBUTING](CONTRIBUTING.md)
 
-[trav_img]: https://api.travis-ci.org/FormidableLabs/formidable-react-component-boilerplate.svg
-[trav_site]: https://travis-ci.org/FormidableLabs/formidable-react-component-boilerplate
+[trav_img]: https://api.travis-ci.org/FormidableLabs/victory-tree.svg
+[trav_site]: https://travis-ci.org/FormidableLabs/victory-tree
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "victory-tree",
   "version": "0.1.5",
-  "description": "",
+  "description": "Tree Layout Component for Victory",
   "main": "lib/index.js",
   "repository": {
     "type": "git",
@@ -14,13 +14,16 @@
   },
   "homepage": "https://github.com/FormidableLabs/victory-tree",
   "scripts": {
-    "prepublish": "npm run build",
+    "postinstall": "npm run build-lib",
+    "preversion": "npm run check",
+    "version": "npm run clean && npm run build && git add -A dist",
     "clean-dist": "rimraf dist",
     "build-dist-min": "webpack --config webpack.config.js",
     "build-dist-dev": "webpack --config webpack.config.dev.js",
     "build-dist": "npm run clean-dist && npm run build-dist-min && npm run build-dist-dev",
     "clean-lib": "rimraf lib",
     "build-lib": "npm run clean-lib && babel --stage 0 src -d lib",
+    "clean": "npm run clean-lib && npm run clean-dist",
     "build": "npm run build-lib && npm run build-dist",
     "server-dev": "webpack-dev-server --port 3000 --config demo/webpack.config.dev.js --content-base demo",
     "server-hot": "webpack-dev-server --port 3000 --config demo/webpack.config.hot.js --hot --content-base demo",


### PR DESCRIPTION
cc/ @colinmegill 

This PR updates the release scripts and docs, and adds an `.npmignore`.  This PR also moves the development docs to their own markdown file so that the readme will be less cluttered. Basically just mirrors what's changed in the boilerplate.
