### PR TITLE
add es6 polyfill for phantomjs

### DIFF
--- a/karma.conf.dev.js
+++ b/karma.conf.dev.js
@@ -14,6 +14,8 @@ module.exports = function (config) {
     browsers: ["PhantomJS"],
     basePath: ".", // repository root.
     files: [
+      // es6 polyfill for phantom
+      "node_modules/babel-core/browser-polyfill.js",
       // Sinon has issues with webpack. Do global include.
       "node_modules/sinon/pkg/sinon.js",
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -24,6 +24,8 @@ module.exports = function (config) {
       "test/client/main.js": ["webpack"]
     },
     files: [
+      // es6 polyfill for phantom
+      "node_modules/babel-core/browser-polyfill.js",
       // Sinon has issues with webpack. Do global include.
       "node_modules/sinon/pkg/sinon.js",
 


### PR DESCRIPTION
cc/ @colinmegill 

This PR adds an es6 polyfill for phantomjs. This is necessary because libraries like d3-ease are published as non-transpiled es6. Weird errors were happening in test
